### PR TITLE
Fix 'maven-shade-plugin' configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,15 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/MANIFEST.MF</exclude>
+              </excludes>
+            </filter>
+          </filters>
           <outputFile>coinbase-fix-example.jar</outputFile>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
The plugin behavior has changed between the previously used version, 3.2.1, and the currently used version, 3.4.0.