### PR TITLE
Remove SLF4J dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>11</java.version>
     <philadelphia.version>2.0.0</philadelphia.version>
-    <slf4j.version>2.0.7</slf4j.version>
   </properties>
 
   <dependencies>
@@ -57,16 +56,6 @@
       <groupId>com.typesafe</groupId>
       <artifactId>config</artifactId>
       <version>1.4.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-nop</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
TLS Channel 0.8.0 no longer needs it.